### PR TITLE
Refactor SinglyLinkedList to use generics and add features

### DIFF
--- a/Datenstrukturen/SinglyLinkedList.cs
+++ b/Datenstrukturen/SinglyLinkedList.cs
@@ -9,8 +9,6 @@ namespace Datenstrukturen
 {
     public class SinglyLinkedList<T>
     {
-        public Node<T> Head => head;
-
         private static Node<T> head;
         public Node<T> InsertAtEnd(T person)
         {
@@ -76,49 +74,8 @@ namespace Datenstrukturen
             return newNode2;
 
         }
-        public Node<T> InsertAtSpecificPosition(int pos, T person)
-        {
-            if(pos<1)
-            {
-                return head;
-            }
-            if (pos == 1)
-            {
-                Node<T> newNode = new Node<T>(person);
-                newNode.Next = head;
-                head = newNode;
-                return newNode;
-            }
-            Node<T> current = head;
-            for (int i = 1; i < pos -1 && current != null; i++)
-            {
-                current = current.Next;
-            }
-            if (current == null)
-            {
-                return head;
-            }
-            Node<T> newNode2 = new Node<T>(person);
-            newNode2.Next = current.Next;
-            current.Next = newNode2;
-            return head;
-        }
 
-        public Node<T> SearchNode(Func<T, bool> match)
-        {
-            var current = head;
-            while (current != null)
-            {
-                if (match(current.Data))
-                {
-                    return current;
-                }
-                current = current.Next;
-            }
-            return null;
-        }
-
-        public int PosOfElement(T person )
+        public int PosOfElement(T person)
         {
             Node<T> current = head;
             int pos = 0;
@@ -131,7 +88,7 @@ namespace Datenstrukturen
                 current = current.Next;
                 pos++;
             }
-            return -1; // Element nicht gefunden
+            return -1; 
         }
 
         public void printSinglyLinkedList()

--- a/Datenstrukturen/SinglyLinkedList.cs
+++ b/Datenstrukturen/SinglyLinkedList.cs
@@ -7,18 +7,20 @@ using Common;
 
 namespace Datenstrukturen
 {
-    public class SinglyLinkedList
+    public class SinglyLinkedList<T>
     {
-        private static Node<Person> head;
-        public static Node<Person> insertAtEnd(Person person)
+        public Node<T> Head => head;
+
+        private static Node<T> head;
+        public Node<T> InsertAtEnd(T person)
         {
-            Node<Person> newNode = new Node<Person>(person);
+            Node<T> newNode = new Node<T>(person);
             if (head == null)
             {
                 head = newNode;
                 return newNode;
             }
-            Node<Person> last = head;
+            Node<T> last = head;
             while (last.Next != null)
             {
                 last = last.Next;
@@ -26,8 +28,55 @@ namespace Datenstrukturen
             last.Next = newNode;
             return head;
         }
+        public Node<T> InsertAfter(T elementBefore, T elementToInsert)
+        {
+            Node<T> current = head;
+            if(head.Data.Equals(elementBefore))
+            {
+                Node<T> newNode = new Node<T>(elementToInsert);
+                head.Next = newNode;
+                head = newNode;
+                return head;
+            }
+            while (current != null && !current.Data.Equals(elementBefore))
+            {
+                current = current.Next;
+            }
+            if (current == null)
+            {
+                return null;
+            }
+            Node<T> newNode2 = new Node<T>(elementToInsert);
+            current.Next = newNode2;
+            newNode2.Next = current.Next.Next;
+            return newNode2;
+        }
+        public Node<T> InsertBefore(T elementAfter, T elementToInsert)
+        {
+            Node<T> current = head;
+            if (head != null && head.Data.Equals(elementAfter))
+            {
+                Node<T> newNode = new Node<T>(elementToInsert);
+                newNode.Next = head;
+                head = newNode;
+                return newNode;
+            }
+            while (current != null && current.Next != null && !current.Next.Data.Equals(elementAfter))
+            {
+                current = current.Next;
+            }
 
-        public static Node<Person> insertAtSpecificPosition(int pos, Person person)
+            if (current.Next == null)
+            {
+                return null;
+            }
+            Node<T> newNode2 = new Node<T>(elementToInsert);
+            newNode2.Next = current.Next;
+            current.Next = newNode2;
+            return newNode2;
+
+        }
+        public Node<T> InsertAtSpecificPosition(int pos, T person)
         {
             if(pos<1)
             {
@@ -35,12 +84,12 @@ namespace Datenstrukturen
             }
             if (pos == 1)
             {
-                Node<Person> newNode = new Node<Person>(person);
+                Node<T> newNode = new Node<T>(person);
                 newNode.Next = head;
                 head = newNode;
                 return newNode;
             }
-            Node<Person> current = head;
+            Node<T> current = head;
             for (int i = 1; i < pos -1 && current != null; i++)
             {
                 current = current.Next;
@@ -49,18 +98,18 @@ namespace Datenstrukturen
             {
                 return head;
             }
-            Node<Person> newNode2 = new Node<Person>(person);
+            Node<T> newNode2 = new Node<T>(person);
             newNode2.Next = current.Next;
             current.Next = newNode2;
             return head;
         }
 
-        public static Node<Person> searchNode(string name)
+        public Node<T> SearchNode(Func<T, bool> match)
         {
-            Node<Person> current = head;
+            var current = head;
             while (current != null)
             {
-                if (current.Data.Name == name)
+                if (match(current.Data))
                 {
                     return current;
                 }
@@ -69,9 +118,25 @@ namespace Datenstrukturen
             return null;
         }
 
-        public static void printSinglyLinkedList()
+        public int PosOfElement(T person )
         {
-            Node<Person> current = head;
+            Node<T> current = head;
+            int pos = 0;
+            while (current != null)
+            {
+                if (current.Data.Equals(person))
+                {
+                    return pos;
+                }
+                current = current.Next;
+                pos++;
+            }
+            return -1; // Element nicht gefunden
+        }
+
+        public void printSinglyLinkedList()
+        {
+            Node<T> current = head;
             while (current != null)
             {
                 Console.WriteLine(current.Data);

--- a/Datenstrukturen/SinglyLinkedList.cs
+++ b/Datenstrukturen/SinglyLinkedList.cs
@@ -34,8 +34,8 @@ namespace Datenstrukturen
             if(head.Data.Equals(elementBefore))
             {
                 Node<T> newNode = new Node<T>(elementToInsert);
+                newNode.Next = head.Next;
                 head.Next = newNode;
-                head = newNode;
                 return head;
             }
             while (current != null && !current.Data.Equals(elementBefore))
@@ -47,8 +47,8 @@ namespace Datenstrukturen
                 return null;
             }
             Node<T> newNode2 = new Node<T>(elementToInsert);
+            newNode2.Next = current.Next;
             current.Next = newNode2;
-            newNode2.Next = current.Next.Next;
             return newNode2;
         }
         public Node<T> InsertBefore(T elementAfter, T elementToInsert)

--- a/SinglyLinkedListTest/SinglyLinkedListTests.cs
+++ b/SinglyLinkedListTest/SinglyLinkedListTests.cs
@@ -1,5 +1,6 @@
 using Common;
 using Datenstrukturen;
+using System;
 namespace SinglyLinkedListTest
 {
     public class Tests
@@ -7,38 +8,109 @@ namespace SinglyLinkedListTest
         [Test]
         public void InsertAtEnd_AddsNodeCorrectly()
         {
-            Node<Person> head = null;
-            head = SinglyLinkedList.insertAtEnd(new Person(new DateTime(2000, 1, 1), "weiblich", "Onur"));
-            head = SinglyLinkedList.insertAtEnd(new Person(new DateTime(2000, 1, 1), "weiblich", "Arslan"));
+            var list = new SinglyLinkedList<Person>();
 
-            Assert.AreEqual("Onur", head.Data.Name);
-            Assert.AreEqual("Arslan", head.Next.Data.Name);
-            Assert.IsNull(head.Next.Next);
+            Person p1 = new Person(new DateTime(2000, 1, 1), "weiblich", "Onur");
+            Person p2 = new Person(new DateTime(2000, 1, 1), "weiblich", "Arslan");
+
+            list.InsertAtEnd(p1);
+            list.InsertAtEnd(p2);
+
+            Assert.AreEqual("Onur", list.Head.Data.Name);
+            Assert.AreEqual("Arslan", list.Head.Next.Data.Name);
+            Assert.IsNull(list.Head.Next.Next);
         }
         [Test]
         public void InsertAtSpecificPosition_AddsNodeAtCorrectPosition()
         {
-            Node<Person> head = null;
-            head = SinglyLinkedList.insertAtEnd(new Person(new DateTime(2000, 1, 1), "weiblich", "Onur"));
-            head = SinglyLinkedList.insertAtEnd(new Person(new DateTime(2000, 1, 1), "weiblich", "Arslan"));
-            head = SinglyLinkedList.insertAtSpecificPosition(2, new Person(new DateTime(2000, 1, 1), "männlich", "Mehmet"));
+            var list = new SinglyLinkedList<Person>();
 
-            Assert.AreEqual("Onur", head.Data.Name);
-            Assert.AreEqual("Mehmet", head.Next.Data.Name);
-            Assert.AreEqual("Arslan", head.Next.Next.Data.Name);
-            Assert.IsNull(head.Next.Next.Next);
+            Person p1 = new Person(new DateTime(2000, 1, 1), "weiblich", "Onur");
+            Person p2 = new Person(new DateTime(2000, 1, 1), "weiblich", "Arslan");
+            Person p3 = new Person(new DateTime(2000, 1, 1), "männlich", "Mehmet");
+
+            list.InsertAtEnd(p1);
+            list.InsertAtEnd(p2);
+            list.InsertAtSpecificPosition(2, p3);
+
+            Assert.AreEqual("Onur", list.Head.Data.Name);
+            Assert.AreEqual("Mehmet", list.Head.Next.Data.Name);
+            Assert.AreEqual("Arslan", list.Head.Next.Next.Data.Name);
+            Assert.IsNull(list.Head.Next.Next.Next);
         }
+
         [Test]
-        public void SearchSpecificPerson_ReturnsCorrectNode()
+        public void Search_ReturnsCorrectNode()
         {
-            Node<Person> head = null;
-            head = SinglyLinkedList.insertAtEnd(new Person(new DateTime(2000, 1, 1), "weiblich", "Onur"));
-            head = SinglyLinkedList.insertAtEnd(new Person(new DateTime(2000, 1, 1), "weiblich", "Arslan"));
-            head = SinglyLinkedList.insertAtEnd(new Person(new DateTime(2000, 1, 1), "weiblich", "Maurice"));
-            Node<Person> result = SinglyLinkedList.searchNode("Arslan");
+            var list = new SinglyLinkedList<Person>();
+
+            Person p1 = new Person(new DateTime(2000, 1, 1), "weiblich", "Onur");
+            Person p2 = new Person(new DateTime(2000, 1, 1), "weiblich", "Arslan");
+            Person p3 = new Person(new DateTime(2000, 1, 1), "weiblich", "Maurice");
+
+            list.InsertAtEnd(p1);
+            list.InsertAtEnd(p2);
+            list.InsertAtEnd(p3);
+
+            var result = list.SearchNode(p => p.Name == "Arslan");
 
             Assert.IsNotNull(result);
             Assert.AreEqual("Arslan", result.Data.Name);
+        }
+        [Test]
+        public void InsertBefore_ReturnsCorrectNode()
+        {
+            var list = new SinglyLinkedList<Person>();
+            Person p1 = new Person(new DateTime(2000, 1, 1), "weiblich", "Onur");
+            Person p2 = new Person(new DateTime(2000, 1, 1), "weiblich", "Arslan");
+            Person p3 = new Person(new DateTime(2000, 1, 1), "männlich", "Mehmet");
+            Person p4 = new Person(new DateTime(2000, 1, 1), "männlich", "Gabriel");
+
+            list.InsertAtEnd(p1);
+            list.InsertAtEnd(p2);
+            list.InsertAtEnd(p3);
+
+            list.InsertBefore(p2, p4);
+
+            Assert.IsNotNull(list.Head.Next.Next.Next);
+            Assert.AreEqual("Gabriel", list.Head.Next.Data.Name);
+        }
+        [Test]
+        public void InsertAfter_ReturnsCorrectNode()
+        {
+            var list = new SinglyLinkedList<Person>();
+            Person p1 = new Person(new DateTime(2000, 1, 1), "weiblich", "Onur");
+            Person p2 = new Person(new DateTime(2000, 1, 1), "weiblich", "Arslan");
+            Person p3 = new Person(new DateTime(2000, 1, 1), "männlich", "Mehmet");
+            Person p4 = new Person(new DateTime(2000, 1, 1), "männlich", "Gabriel");
+
+            list.InsertAtEnd(p1);
+            list.InsertAtEnd(p2);
+            list.InsertAtEnd(p3);
+
+            list.InsertAfter(p2, p4);
+
+            Assert.IsNotNull(list.Head.Next.Next.Next);
+            Assert.AreEqual("Gabriel", list.Head.Next.Next.Data.Name);
+        }
+
+        [Test]
+        public void PosOfElement_ReturnCorrectPosNumber()
+        {
+            var list = new SinglyLinkedList<Person>();
+            Person p1 = new Person(new DateTime(2000, 1, 1), "weiblich", "Onur");
+            Person p2 = new Person(new DateTime(2000, 1, 1), "weiblich", "Arslan");
+            Person p3 = new Person(new DateTime(2000, 1, 1), "männlich", "Mehmet");
+            Person p4 = new Person(new DateTime(2000, 1, 1), "männlich", "Gabriel");
+
+            list.InsertAtEnd(p1);
+            list.InsertAtEnd(p2);
+            list.InsertAtEnd(p3);
+            list.InsertAtEnd(p4);
+
+            int result = list.PosOfElement(p3);
+            Assert.IsNotNull(list.Head.Next.Next.Next);
+            Assert.AreEqual(2, result);
         }
     }
 }

--- a/SinglyLinkedListTest/SinglyLinkedListTests.cs
+++ b/SinglyLinkedListTest/SinglyLinkedListTests.cs
@@ -3,113 +3,67 @@ using Datenstrukturen;
 using System;
 namespace SinglyLinkedListTest
 {
+    [TestFixture]
     public class Tests
     {
-        [Test]
-        public void InsertAtEnd_AddsNodeCorrectly()
+        private SinglyLinkedList<Person> list;
+        private Person p1;
+        private Person p2;
+        private Person p3;
+        private Person p4;
+
+        [SetUp]
+        public void SetUp()
         {
-            var list = new SinglyLinkedList<Person>();
+            list = new SinglyLinkedList<Person>();
 
-            Person p1 = new Person(new DateTime(2000, 1, 1), "weiblich", "Onur");
-            Person p2 = new Person(new DateTime(2000, 1, 1), "weiblich", "Arslan");
-
-            list.InsertAtEnd(p1);
-            list.InsertAtEnd(p2);
-
-            Assert.AreEqual("Onur", list.Head.Data.Name);
-            Assert.AreEqual("Arslan", list.Head.Next.Data.Name);
-            Assert.IsNull(list.Head.Next.Next);
-        }
-        [Test]
-        public void InsertAtSpecificPosition_AddsNodeAtCorrectPosition()
-        {
-            var list = new SinglyLinkedList<Person>();
-
-            Person p1 = new Person(new DateTime(2000, 1, 1), "weiblich", "Onur");
-            Person p2 = new Person(new DateTime(2000, 1, 1), "weiblich", "Arslan");
-            Person p3 = new Person(new DateTime(2000, 1, 1), "männlich", "Mehmet");
-
-            list.InsertAtEnd(p1);
-            list.InsertAtEnd(p2);
-            list.InsertAtSpecificPosition(2, p3);
-
-            Assert.AreEqual("Onur", list.Head.Data.Name);
-            Assert.AreEqual("Mehmet", list.Head.Next.Data.Name);
-            Assert.AreEqual("Arslan", list.Head.Next.Next.Data.Name);
-            Assert.IsNull(list.Head.Next.Next.Next);
+            p1 = new Person(new DateTime(2000, 1, 1), "weiblich", "Onur");
+            p2 = new Person(new DateTime(2000, 1, 1), "weiblich", "Arslan");
+            p3 = new Person(new DateTime(2000, 1, 1), "männlich", "Mehmet");
+            p4 = new Person(new DateTime(2000, 1, 1), "männlich", "Gabriel");
         }
 
         [Test]
-        public void Search_ReturnsCorrectNode()
+        public void InsertAtEnd_InsertTwoElementsInEmptyList_AddNodesCorrectly()
         {
-            var list = new SinglyLinkedList<Person>();
-
-            Person p1 = new Person(new DateTime(2000, 1, 1), "weiblich", "Onur");
-            Person p2 = new Person(new DateTime(2000, 1, 1), "weiblich", "Arslan");
-            Person p3 = new Person(new DateTime(2000, 1, 1), "weiblich", "Maurice");
-
             list.InsertAtEnd(p1);
             list.InsertAtEnd(p2);
-            list.InsertAtEnd(p3);
 
-            var result = list.SearchNode(p => p.Name == "Arslan");
-
-            Assert.IsNotNull(result);
-            Assert.AreEqual("Arslan", result.Data.Name);
+            Assert.AreEqual(0, list.PosOfElement(p1));
+            Assert.AreEqual(1, list.PosOfElement(p2));
         }
+
         [Test]
         public void InsertBefore_ReturnsCorrectNode()
         {
-            var list = new SinglyLinkedList<Person>();
-            Person p1 = new Person(new DateTime(2000, 1, 1), "weiblich", "Onur");
-            Person p2 = new Person(new DateTime(2000, 1, 1), "weiblich", "Arslan");
-            Person p3 = new Person(new DateTime(2000, 1, 1), "männlich", "Mehmet");
-            Person p4 = new Person(new DateTime(2000, 1, 1), "männlich", "Gabriel");
-
             list.InsertAtEnd(p1);
             list.InsertAtEnd(p2);
             list.InsertAtEnd(p3);
 
             list.InsertBefore(p2, p4);
 
-            Assert.IsNotNull(list.Head.Next.Next.Next);
-            Assert.AreEqual("Gabriel", list.Head.Next.Data.Name);
+            Assert.AreEqual(1, list.PosOfElement(p4));
         }
         [Test]
         public void InsertAfter_ReturnsCorrectNode()
         {
-            var list = new SinglyLinkedList<Person>();
-            Person p1 = new Person(new DateTime(2000, 1, 1), "weiblich", "Onur");
-            Person p2 = new Person(new DateTime(2000, 1, 1), "weiblich", "Arslan");
-            Person p3 = new Person(new DateTime(2000, 1, 1), "männlich", "Mehmet");
-            Person p4 = new Person(new DateTime(2000, 1, 1), "männlich", "Gabriel");
-
             list.InsertAtEnd(p1);
             list.InsertAtEnd(p2);
             list.InsertAtEnd(p3);
 
             list.InsertAfter(p2, p4);
-
-            Assert.IsNotNull(list.Head.Next.Next.Next);
-            Assert.AreEqual("Gabriel", list.Head.Next.Next.Data.Name);
+            Assert.AreEqual(2, list.PosOfElement(p4));
         }
 
         [Test]
         public void PosOfElement_ReturnCorrectPosNumber()
         {
-            var list = new SinglyLinkedList<Person>();
-            Person p1 = new Person(new DateTime(2000, 1, 1), "weiblich", "Onur");
-            Person p2 = new Person(new DateTime(2000, 1, 1), "weiblich", "Arslan");
-            Person p3 = new Person(new DateTime(2000, 1, 1), "männlich", "Mehmet");
-            Person p4 = new Person(new DateTime(2000, 1, 1), "männlich", "Gabriel");
-
             list.InsertAtEnd(p1);
             list.InsertAtEnd(p2);
             list.InsertAtEnd(p3);
             list.InsertAtEnd(p4);
 
             int result = list.PosOfElement(p3);
-            Assert.IsNotNull(list.Head.Next.Next.Next);
             Assert.AreEqual(2, result);
         }
     }


### PR DESCRIPTION
Refactored the `SinglyLinkedList` class to support generics (`<T>`), making it reusable with any data type. Converted static methods to instance methods and added new methods: `InsertAfter`, `InsertBefore`, and `PosOfElement`. Enhanced `SearchNode` to use a predicate for flexible searches. Updated `SinglyLinkedListTests` to reflect these changes, including new test cases for added functionality. Overall, improved flexibility, reusability, and object-oriented design.